### PR TITLE
Detect new `C5` Libre 2 EU and `E6` Libre 1 US14day

### DIFF
--- a/Library/Content/SensorType.swift
+++ b/Library/Content/SensorType.swift
@@ -29,11 +29,11 @@ enum SensorType: String, Codable {
             self = .libre1
         case 0xA2:
             self = .libre1
-        case 0xE5:
+        case 0xE5, 0xE6:
             self = .libreUS14day
         case 0x70:
             self = .libreProH
-        case 0x9D:
+        case 0x9D, 0xC5:
             self = .libre2EU
         case 0x76:
             self = patchInfo[3] == 0x02 ? .libre2US


### PR DESCRIPTION
I didn't test the recent European "C5" and US "E6" sensors but adding these additional codes should be enough to detect them basing on their `patchInfo` (see https://github.com/JohanDegraeve/xdripswift/commit/a33b2c0 and https://github.com/JohanDegraeve/xdripswift/commit/1dace4d ).